### PR TITLE
Initialize client identifiers in layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { Analytics } from '@vercel/analytics/react'
 import Script from 'next/script'
 import SiteFooter from '../components/SiteFooter'
+import ClientIdsInit from '../components/ClientIdsInit'
 import './globals.css'
 
 export const metadata = {
@@ -18,6 +19,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="scroll-smooth">
       <body className="min-h-screen flex flex-col">
+        <ClientIdsInit />
         {/* Datafast tracking */}
         <Script
           src="https://datafa.st/js/script.js"

--- a/src/components/ClientIdsInit.tsx
+++ b/src/components/ClientIdsInit.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useEffect } from 'react'
+import { initClientIds } from '@/lib/initClientIds'
+
+export default function ClientIdsInit() {
+  useEffect(() => {
+    initClientIds()
+  }, [])
+
+  return null
+}

--- a/src/lib/initClientIds.ts
+++ b/src/lib/initClientIds.ts
@@ -1,0 +1,22 @@
+// src/lib/initClientIds.ts
+// Utility to initialize persistent identifiers in the browser.
+
+export function initClientIds(): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    let userId = localStorage.getItem('userId');
+    if (!userId) {
+      userId = crypto.randomUUID();
+      localStorage.setItem('userId', userId);
+    }
+
+    let visitorId = localStorage.getItem('visitorId');
+    if (!visitorId) {
+      visitorId = crypto.randomUUID();
+      localStorage.setItem('visitorId', visitorId);
+    }
+  } catch (err) {
+    console.error('initClientIds failed:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- create `initClientIds` helper for storing IDs in localStorage
- add `ClientIdsInit` client component that runs the helper
- include the new component in `layout.tsx`

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*