### PR TITLE
Add Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.49.4",
     "@vercel/analytics": "^1.4.1",
+    "@vercel/speed-insights": "^1.0.0",
     "clsx": "^2.1.1",
     "next": "15.1.3",
     "react": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 import type { ReactNode } from 'react'
 import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 import Script from 'next/script'
 import SiteFooter from '../components/SiteFooter'
 import ClientIdsInit from '../components/ClientIdsInit'
@@ -36,6 +37,7 @@ export default function RootLayout({
 
         {/* Vercel Analytics */}
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- add `@vercel/speed-insights` dependency
- render `<SpeedInsights />` in app layout

## Testing
- `npm run lint` *(fails: `next` not found)*