### PR TITLE
Remove Google login option

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -103,7 +103,8 @@ function LoginInner() {
               },
             },
           }}
-          providers={['google']}
+          /* only show email/password fields */
+          providers={[]}
           redirectTo={`${window.location.origin}/login`}
           magicLink={false}
           onlyThirdPartyProviders={false}


### PR DESCRIPTION
## Summary
- update login form to only offer email/password sign-in

## Testing
- `npm run lint` *(fails: next not found)*