### PR TITLE
Fix login auth redirect behavior

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -64,9 +64,13 @@ function LoginInner() {
   /*  Listen for auth state changes and act once the user is signed in      */
   /* ---------------------------------------------------------------------- */
   useEffect(() => {
-    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === 'SIGNED_IN' && session) handlePostSignIn(session)
-    })
+    const { data: sub } = supabase.auth.onAuthStateChange(
+      (event, session) => {
+        if ((event === 'SIGNED_IN' || event === 'INITIAL_SESSION') && session) {
+          handlePostSignIn(session)
+        }
+      }
+    )
     return () => sub.subscription.unsubscribe()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // run once
@@ -104,7 +108,6 @@ function LoginInner() {
             },
           }}
           providers={['google']}
-          redirectTo={`${window.location.origin}/login`}
           magicLink={false}
           onlyThirdPartyProviders={false}
           localization={{ variables: { sign_in: { email_label: 'Email' } } }}


### PR DESCRIPTION
## Summary
- prevent `Auth` from auto-navigating back to `/login`
- trigger post-sign-in logic for both sign-in events and initial sessions

## Testing
- `npm run lint` *(fails: `next` not found)*