### PR TITLE
Update membership checks to handle missing email

### DIFF
--- a/src/app/check-membership/page.tsx
+++ b/src/app/check-membership/page.tsx
@@ -23,7 +23,7 @@ export default async function CheckMembershipPage() {
 
     if (!response.ok) {
       console.error('Member status API failed:', response.status)
-      redirect('/checkout')
+      redirect('/signup')
     }
 
     const { isMember } = await response.json()
@@ -34,12 +34,12 @@ export default async function CheckMembershipPage() {
       console.log('✅ Is member, redirecting to /members')
       redirect('/members')
     } else {
-      console.log('❌ Not a member, redirecting to checkout')
-      redirect('/checkout')  
+      console.log('❌ Not a member, redirecting to signup')
+      redirect('/signup')
     }
 
   } catch (error) {
     console.error('Membership check error:', error)
-    redirect('/checkout')
+    redirect('/signup')
   }
 }

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -9,11 +9,18 @@ import TennisCourtList from '../tennis-courts/components/TennisCourtList'
 import { Button } from '@/components/ui/button'
 
 /* NEW – helper that runs on the server via a tiny API route */
-async function fetchMemberStatus(): Promise<boolean> {
-  const r = await fetch('/api/member-status', { cache: 'no-store' })
-  if (!r.ok) return false
-  const { isMember } = (await r.json()) as { isMember: boolean }
-  return isMember === true
+async function fetchMemberStatus(email: string | undefined): Promise<boolean> {
+  if (!email) return false
+  try {
+    const r = await fetch(`/api/member-status?email=${encodeURIComponent(email)}`, {
+      cache: 'no-store',
+    })
+    if (!r.ok) return false
+    const { isMember } = (await r.json()) as { isMember: boolean }
+    return isMember === true
+  } catch {
+    return false
+  }
 }
 
 export default function MembersPage() {
@@ -43,7 +50,7 @@ export default function MembersPage() {
         setSessionAccessToken(session.access_token)
 
         /* ───────── 2) require active / trialing sub ───────── */
-        const ok = await fetchMemberStatus()
+        const ok = await fetchMemberStatus(session.user.email)
         if (!ok) {
           const resp = await fetch('/api/create-checkout-session', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- make `fetchMemberStatus` robust to missing email
- redirect to the signup page from the membership check

## Testing
- `npm run lint` *(fails: `next` not found)*