### PR TITLE
Update member status logic

### DIFF
--- a/src/app/check-membership/page.tsx
+++ b/src/app/check-membership/page.tsx
@@ -16,14 +16,14 @@ export default async function CheckMembershipPage() {
   console.log('🔍 Checking membership for:', user.email)
 
   try {
-    // Call your existing API
-    const response = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/member-status?email=${encodeURIComponent(user.email)}`, {
+    // Call your existing API using a relative URL to avoid env issues
+    const response = await fetch(`/api/member-status?email=${encodeURIComponent(user.email)}`, {
       cache: 'no-store'
     })
 
     if (!response.ok) {
       console.error('Member status API failed:', response.status)
-      redirect('/checkout')
+      redirect('/signup')
     }
 
     const { isMember } = await response.json()
@@ -34,12 +34,12 @@ export default async function CheckMembershipPage() {
       console.log('✅ Is member, redirecting to /members')
       redirect('/members')
     } else {
-      console.log('❌ Not a member, redirecting to checkout')
-      redirect('/checkout')  
+      console.log('❌ Not a member, redirecting to signup')
+      redirect('/signup')
     }
 
   } catch (error) {
     console.error('Membership check error:', error)
-    redirect('/checkout')
+    redirect('/signup')
   }
 }

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -9,8 +9,11 @@ import TennisCourtList from '../tennis-courts/components/TennisCourtList'
 import { Button } from '@/components/ui/button'
 
 /* NEW – helper that runs on the server via a tiny API route */
-async function fetchMemberStatus(): Promise<boolean> {
-  const r = await fetch('/api/member-status', { cache: 'no-store' })
+async function fetchMemberStatus(email: string | null | undefined): Promise<boolean> {
+  if (!email) return false
+  const r = await fetch(`/api/member-status?email=${encodeURIComponent(email)}`, {
+    cache: 'no-store',
+  })
   if (!r.ok) return false
   const { isMember } = (await r.json()) as { isMember: boolean }
   return isMember === true
@@ -43,7 +46,7 @@ export default function MembersPage() {
         setSessionAccessToken(session.access_token)
 
         /* ───────── 2) require active / trialing sub ───────── */
-        const ok = await fetchMemberStatus()
+        const ok = await fetchMemberStatus(session.user.email)
         if (!ok) {
           const resp = await fetch('/api/create-checkout-session', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- redirect failed memberships to signup instead of nonexistent checkout route
- look up member status with relative API call and guard when email is missing

## Testing
- `npm run lint` *(fails: `next` not found)*